### PR TITLE
PHP redis v3.1.6

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -3,7 +3,7 @@
 _php=php5
 pkgname=$_php-redis
 _pkgrealname=redis
-pkgver=3.1.5
+pkgver=3.1.6
 pkgrel=0
 pkgdesc="PHP extension for interfacing with Redis"
 url="http://pecl.php.net/redis"
@@ -41,4 +41,4 @@ package() {
 	done
 }
 
-sha512sums="9d19d8ff2af92ef4da5c8d82daec6307c66db7c3f5171f8ad7d834b01f77ac488b66bd74e6223e76ea7bc6936188341f347756e2f0bbb63ce4a149341c3d6a92  redis-3.1.5.tgz"
+sha512sums="4263d150c93f11dd06587925ad9a3cd8fbba2e4a18b2f23e6adfaeb25d566a1c2d256551a50ae1b9c770fd0f9bc4c92f483c46d60be9d4f5b5ba056231b7d527  redis-3.1.6.tgz"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The current installation method for these packages is to pull them in using
 
     apk --no-cache add ca-certificates wget
     wget --quiet --output-document=/etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-php5-redis/releases/download/3.1.5-r0/php5-redis-3.1.5-r0.apk
-    apk add php5-redis-3.1.5-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-php5-redis/releases/download/3.1.6-r0/php5-redis-3.1.6-r0.apk
+    apk add php5-redis-3.1.6-r0.apk
 
 [php-redis]: https://pecl.php.net/redis


### PR DESCRIPTION
💁 This change updates the [PHP extension for Redis](https://pecl.php.net/package/redis) to version  3.1.6.